### PR TITLE
Fix values stored and returned from FormData

### DIFF
--- a/FormData.js
+++ b/FormData.js
@@ -113,7 +113,7 @@ class FormDataPolyfill {
     let map = wm(this)
     name += ''
 
-    return map[name] ? map[name][0] : null
+    return map[name] ? map[name][0][0] : null
   }
 
 

--- a/FormData.js
+++ b/FormData.js
@@ -49,6 +49,9 @@ class FormDataPolyfill {
     if (!map[name])
       map[name] = []
 
+    if (!(value instanceof File) && !(value instanceof Blob) && typeof value != 'string') {
+      value += ''
+    }
     map[name].push([value, filename])
   }
 
@@ -159,6 +162,9 @@ class FormDataPolyfill {
    * @return  {Undefined}
    */
   set(name, value, filename) {
+    if (!(value instanceof File) && !(value instanceof Blob) && typeof value != 'string') {
+      value += ''
+    }
     wm(this)[name + ''] = [[value, filename]]
   }
 

--- a/FormData.js
+++ b/FormData.js
@@ -127,7 +127,7 @@ class FormDataPolyfill {
    * @return  {Array}   [name, value]
    */
   getAll(name) {
-    return (wm(this)[name += ''] || []).concat()
+    return (wm(this)[name += ''] || []).concat().map(v => v[0])
   }
 
 

--- a/FormData.js
+++ b/FormData.js
@@ -49,10 +49,7 @@ class FormDataPolyfill {
     if (!map[name])
       map[name] = []
 
-    if (!(value instanceof File) && !(value instanceof Blob) && typeof value != 'string') {
-      value += ''
-    }
-    map[name].push([value, filename])
+    map[name].push([value instanceof Blob ? value : value + '', filename])
   }
 
 
@@ -127,7 +124,7 @@ class FormDataPolyfill {
    * @return  {Array}   [name, value]
    */
   getAll(name) {
-    return (wm(this)[name += ''] || []).concat().map(v => v[0])
+    return (wm(this)[name += ''] || []).map(v => v[0])
   }
 
 
@@ -162,10 +159,7 @@ class FormDataPolyfill {
    * @return  {Undefined}
    */
   set(name, value, filename) {
-    if (!(value instanceof File) && !(value instanceof Blob) && typeof value != 'string') {
-      value += ''
-    }
-    wm(this)[name + ''] = [[value, filename]]
+    wm(this)[name + ''] = [[value instanceof Blob ? value : value + '', filename]]
   }
 
 


### PR DESCRIPTION
There are two changes:

1. `get` currently returns the wrong value of `[val, val]` instead of `val` (first value of the array, 2nd value is actually the `filename`). This PR fixes it.
2. Make sure `set` and `append` will convert any values to `string`, `Blob` or `File` before storing them. So if `formdata.set('test', 10)` is run, `formdata.get('test')` will return a `string` (`"10"`) instead of `number` (`10`).