### PR TITLE
Support for Safari 10

### DIFF
--- a/FormData.js
+++ b/FormData.js
@@ -47,7 +47,7 @@ class FormDataPolyfill {
     if (!form)
       return this
 
-    for (let {name, type, value, files, checked, selectedOptions} of form.elements) {
+    for (let {name, type, value, files, checked, selectedOptions} of Array.from(form.elements)) {
       if(!name) continue
 
       if (type === 'file')


### PR DESCRIPTION
In Safari 10 `NodeList` does not implement the iterator protocol. Wrapping the NodeList instance in `Array.from()` will return a real Array and that will make the iterator protocol, and this module, work just fine.

```js
const elements = document.getElementsByTagName('div');
console.log(typeof elements[Symbol.iterator]); // undefined in Safari
```