### PR TITLE
Ensure boundary is always lowercase.

### DIFF
--- a/FormData.js
+++ b/FormData.js
@@ -224,7 +224,7 @@ class FormDataPolyfill {
    * @return {Blob} [description]
    */
   _blob() {
-    var boundary = '----FormDataPolyfill' + Math.random()
+    var boundary = '----formdata-polyfill-' + Math.random()
     var chunks = []
 
     for (let [name, value] of this) {


### PR DESCRIPTION
Resolves an issue with Google Chrome forcing the Blob type to lowercase, which causes the request data to become invalid.

![image](https://cloud.githubusercontent.com/assets/37948/24389122/f70b3056-13ca-11e7-806e-9f7d6c36515e.png)

closes #17