### PR TITLE
Readme tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@
 npm install formdata-polyfill
 ```
 
-A FormData polyfill
+A `FormData` polyfill
 
-This polyfill conditionally replace the native implementation rather then fixing the missing functions
-since there is no way to get/delete something that you have appended already.
-Therefore this also patches `xhr.prototype.send` and `fetch` to instead send the FormData as a blob
+This polyfill conditionally replaces the native implementation rather then fixing the missing functions,
+since otherwise there is no way to get or delete existing values in the FormData object.
+Therefore this also patches `XMLHttpRequest.prototype.send` and `fetch` to send the FormData as a blob.
 
-I was unable to patch Response/Request constructor
-so if you are constructing them with a FormData you need to call `fd._blob()` manually.
+I was unable to patch the Response/Request constructor
+so if you are constructing them with FormData you need to call `fd._blob()` manually.
 
 ```js
 new Request(url, {
@@ -25,16 +25,16 @@ new Request(url, {
 Dependencies
 ---
 
-I do keep the internal data private to prevent unintentional access to them,
-therefore `WeakMap` is used and you may need a polyfill for that also.
+The internal data is kept private to prevent unintentional access to it,
+therefore `WeakMap` is used and you may also need a polyfill for that.
 
 Updating from 2.x to 3.x
 ---
 
 Previously you had to import the polyfill and use that,
-since it didn't replace the global (existing) FormData.
-But now it transparently calls `_blob()` for you when you are sending something with fetch or XHR.
-This polyfill dose now monkey patch the `send` and `fetch` function.
+since it didn't replace the global (existing) FormData implementation.
+But now it transparently calls `_blob()` for you when you are sending something with fetch or XHR,
+by way of monkey-patching the `XMLHttpRequest.prototype.send` and `fetch` functions.
 
 So you maybe had something like this:
 
@@ -44,10 +44,12 @@ var fd = new FormData(form)
 xhr.send(fd._blob())
 ```
 
-But that is changed now, there is no module export any longer.
-So you just have to do like you normal would:
+There is no longer anything exported from the module
+(though you of course still need to import it to install the polyfill),
+so you can now use the FormData object as normal:
 
 ```javascript
+require('formdata-polyfill')
 var fd = new FormData(form)
 xhr.send(fd)
 ```
@@ -55,12 +57,12 @@ xhr.send(fd)
 The status of the native FormData (2016-10-19) is:
 [![skarmavbild 2016-10-19 kl 21 32 19](https://cloud.githubusercontent.com/assets/1148376/19534352/b7f42d8c-9643-11e6-91da-7f89580f51d8.png)](https://developer.mozilla.org/en-US/docs/Web/API/FormData#Browser_compatibility)
 
-This lib provides you all the function others don't include
+This polyfill normalizes support for the FormData API:
 
  - `append` with filename
  - `delete()`, `get()`, `getAll()`, `has()`, `set()`
- - `entries()`, `keys()`, `values()`, and support of `for...of`
- - Available in web workers	(yes, just include it...)
+ - `entries()`, `keys()`, `values()`, and support for `for...of`
+ - Available in web workers (just include the polyfill)
 
   [npm-image]: https://img.shields.io/npm/v/formdata-polyfill.svg?style=flat-square
   [npm-url]: https://www.npmjs.com/package/formdata-polyfill

--- a/README.md
+++ b/README.md
@@ -6,10 +6,14 @@
 npm install formdata-polyfill
 ```
 
-A FormData polyfill<br>
-This polyfill conditionally replace the native implementation rather then fixing the missing functions since there is no way to get/delete something that you have appended already. Therefore this also patches `xhr.prototype.send` and `fetch` to instead send the FormData as a blob
+A FormData polyfill
 
-I was unable to patch Response/Request constructor so if you are constructing them with a FormData you need to call `fd._blob()` manually.
+This polyfill conditionally replace the native implementation rather then fixing the missing functions
+since there is no way to get/delete something that you have appended already.
+Therefore this also patches `xhr.prototype.send` and `fetch` to instead send the FormData as a blob
+
+I was unable to patch Response/Request constructor
+so if you are constructing them with a FormData you need to call `fd._blob()` manually.
 
 ```js
 new Request(url, {
@@ -20,12 +24,17 @@ new Request(url, {
 
 Dependencies
 ---
-I do keep the internal data private to prevent unintentional access to them, therefore `WeakMap` is used and you may need a polyfill for that also.
+
+I do keep the internal data private to prevent unintentional access to them,
+therefore `WeakMap` is used and you may need a polyfill for that also.
 
 Updating from 2.x to 3.x
 ---
 
-Previously you had to import the polyfill and use that, since it didn't replace the global (existing) FormData. But now it transparently calls `_blob()` for you when you are sending something with fetch or XHR. This polyfill dose now monkey patch the `send` and `fetch` function.
+Previously you had to import the polyfill and use that,
+since it didn't replace the global (existing) FormData.
+But now it transparently calls `_blob()` for you when you are sending something with fetch or XHR.
+This polyfill dose now monkey patch the `send` and `fetch` function.
 
 So you maybe had something like this:
 
@@ -35,7 +44,8 @@ var fd = new FormData(form)
 xhr.send(fd._blob())
 ```
 
-But that is changed now, there is no module export any longer. So you just have to do like you normal would:
+But that is changed now, there is no module export any longer.
+So you just have to do like you normal would:
 
 ```javascript
 var fd = new FormData(form)
@@ -45,13 +55,12 @@ xhr.send(fd)
 The status of the native FormData (2016-10-19) is:
 [![skarmavbild 2016-10-19 kl 21 32 19](https://cloud.githubusercontent.com/assets/1148376/19534352/b7f42d8c-9643-11e6-91da-7f89580f51d8.png)](https://developer.mozilla.org/en-US/docs/Web/API/FormData#Browser_compatibility)
 
-
 This lib provides you all the function others don't include
+
  - `append` with filename
  - `delete()`, `get()`, `getAll()`, `has()`, `set()`
  - `entries()`, `keys()`, `values()`, and support of `for...of`
  - Available in web workers	(yes, just include it...)
-
 
   [npm-image]: https://img.shields.io/npm/v/formdata-polyfill.svg?style=flat-square
   [npm-url]: https://www.npmjs.com/package/formdata-polyfill


### PR DESCRIPTION
As [requested](https://github.com/jimmywarting/FormData/issues/28#issuecomment-340211806).

The first commit just adds some newlines in the markdown source so the diff is more readable.

The second commit changes some wording.

I added a "require" line to the version 3 example, since otherwise the wording makes it sound like it doesn't need to be imported at all!