### PR TITLE
Fix formdata incorrectly populating buttons into the dataset

### DIFF
--- a/FormData.js
+++ b/FormData.js
@@ -120,7 +120,7 @@ if (typeof FormData === 'undefined' || !FormData.prototype.keys) {
         return this
 
       for (let elm of arrayFrom(form.elements)) {
-        if (!elm.name || elm.disabled) continue
+        if (!elm.name || elm.disabled || elm.type === 'submit' || elm.type === 'button') continue
 
         if (elm.type === 'file')
           for (let file of arrayFrom(elm.files || []))


### PR DESCRIPTION
Theres a problem whereby if the form element contains buttons, there data gets incorrectly added to the object. The actual behaviour in real implementations is that buttons get ignored.

This brings it in line with the specification.