### PR TITLE
Patch navigator.sendBeacon to send data as blob

### DIFF
--- a/FormData.js
+++ b/FormData.js
@@ -12,6 +12,7 @@ if (typeof Blob === 'function' && (typeof FormData === 'undefined' || !FormData.
   // To be monkey patched
   const _send = global.XMLHttpRequest && global.XMLHttpRequest.prototype.send
   const _fetch = global.Request && global.fetch
+  const _sendBeacon = global.navigator && global.navigator.sendBeacon
 
   // Unable to patch Request constructor correctly
   // const _Request = global.Request
@@ -388,6 +389,16 @@ if (typeof Blob === 'function' && (typeof FormData === 'undefined' || !FormData.
       }
 
       return _fetch.call(global, input, init)
+    }
+  }
+
+  // Patch navigator.sendBeacon to use native FormData
+  if (_sendBeacon) {
+    global.navigator.sendBeacon = function (url, data) {
+      if (data instanceof FormDataPolyfill) {
+        data = data['_asNative']()
+      }
+      return _sendBeacon.call(global.navigator, url, data)
     }
   }
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ A `FormData` polyfill
 
 This polyfill conditionally replaces the native implementation rather then fixing the missing functions,
 since otherwise there is no way to get or delete existing values in the FormData object.
-Therefore this also patches `XMLHttpRequest.prototype.send` and `fetch` to send the FormData as a blob.
+Therefore this also patches `XMLHttpRequest.prototype.send` and `fetch` to send the `FormData` as a blob,
+and `navigator.sendBeacon` to send native `FormData`.
 
 I was unable to patch the Response/Request constructor
 so if you are constructing them with FormData you need to call `fd._blob()` manually.


### PR DESCRIPTION
Fixes #74 

Note: It may be possible to use `_asNative` instead but would need testing.