### PR TITLE
fix(readme): wrong file name

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ But NodeJS still laks a proper FormData<br>The good old form-data package is a v
 import fetch from 'node-fetch'
 import File from 'fetch-blob/file.js'
 import { fileFromSync } from 'fetch-blob/from.js'
-import { FormData } from 'formdata-polyfill/esm-min.js'
+import { FormData } from 'formdata-polyfill/esm.min.js'
 
 const file = fileFromSync('./README.md')
 const fd = new FormData()


### PR DESCRIPTION
<!-- Thanks for contributing! -->

## The purpose of this PR is:
There's a tiny typo on the module path in the readme examples . This PR changes the path so it points to the correct file!

## This is what had to change:
`-` -> `.`
(`formdata-polyfill/esm-min.js` -> `formdata-polyfill/esm.min.js`)

-------------------------------------------------------------------------------------------------

<!-- Mark what you have done, Remove unnecessary ones. Add new tasks that may fit (like TODO's) -->
- [X] I prefixed the PR-title with `docs: `, `fix(area): `, `feat(area): ` or `breaking(area): `
- [X] I updated the README.md

