### PR TITLE
fix: null check on hasInstance

### DIFF
--- a/esm.min.js
+++ b/esm.min.js
@@ -18,7 +18,7 @@ export const FormData = class FormData {
 constructor(...a){if(a.length)throw new TypeError(`Failed to construct 'FormData': parameter 1 is not of type 'HTMLFormElement'.`)}
 get [t]() {return 'FormData'}
 [i](){return this.entries()}
-static [h](o) {return typeof o==='object'&&o[t]==='FormData'&&!m.some(m=>typeof o[m]!='function')}
+static [h](o) {return o&&typeof o==='object'&&o[t]==='FormData'&&!m.some(m=>typeof o[m]!='function')}
 append(...a){x('append',arguments,2);this.#d.push(f(...a))}
 delete(a){x('delete',arguments,1);a+='';this.#d=this.#d.filter(([b])=>b!==a)}
 get(a){x('get',arguments,1);a+='';for(var b=this.#d,l=b.length,c=0;c<l;c++)if(b[c][0]===a)return b[c][1];return null}

--- a/test/test-esm.js
+++ b/test/test-esm.js
@@ -76,6 +76,23 @@ for (let [filename, expected] of [['val\nue', 'val%0Aue'], ['val%0Aue', 'val%0Au
   console.assert(fd.has('key3') === true)
 }
 
+class FormDataLike {
+  append(){}
+  set(){}
+  get(){}
+  getAll(){}
+  delete(){}
+  keys(){}
+  values(){}
+  entries(){}
+  forEach(){}
+  get [Symbol.toStringTag](){ return 'FormData' }
+}
+
+console.assert(new FormDataLike() instanceof FormData, 'It should be a formdata like object')
+console.assert(!(null instanceof FormData), 'null check dont throw')
+console.assert(new FormData() instanceof FormData, 'instance check works')
+
 {
   const msg = 'should return the keys/values/entres in the order they was appended'
   const entries = [


### PR DESCRIPTION
<!-- Thanks for contributing! -->

## The purpose of this PR is:
... to not throw if comparing null is a instance of FormData

## This is what had to change:
... first check if obj is truthy



-------------------------------------------------------------------------------------------------

<!-- Mark what you have done, Remove unnecessary ones. Add new tasks that may fit (like TODO's) -->
- [x] I prefixed the PR-title with `docs: `, `fix(area): `, `feat(area): ` or `breaking(area): `
- [x] I Added unit test(s)

-------------------------------------------------------------------------------------------------

<!-- Add a `- fix #_NUMBER_` line for every Issue this PR solves. Do not comma separate them -->
- fix https://github.com/jimmywarting/FormData/pull/136#pullrequestreview-767786804
