### PR TITLE
fix(deps): update fetch-blob version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,20 +1,23 @@
 {
   "name": "formdata-polyfill",
-  "version": "4.0.5",
+  "version": "4.0.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "formdata-polyfill",
-      "version": "4.0.5",
+      "version": "4.0.6",
       "license": "MIT",
       "dependencies": {
-        "fetch-blob": "^3.1.2"
+        "fetch-blob": "^4.0.0"
       },
       "devDependencies": {
         "@types/google-closure-compiler": "^0.0.19",
         "@types/node": "^16.7.10",
         "google-closure-compiler": "^20210808.0.0"
+      },
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/@types/google-closure-compiler": {
@@ -124,9 +127,9 @@
       }
     },
     "node_modules/fetch-blob": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.1.2.tgz",
-      "integrity": "sha512-hunJbvy/6OLjCD0uuhLdp0mMPzP/yd2ssd1t2FCJsaA7wkWhpbp9xfuNVpv7Ll4jFhzp6T4LAupSiV9uOeg0VQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-4.0.0.tgz",
+      "integrity": "sha512-nPmnhRmpNMjYWnp9EBMGs6z5lq9RXed5W1vuZcECrsDVQInM8AMQSooVb3X183Aole60adzjWbH9qlRFWzDDTA==",
       "funding": [
         {
           "type": "github",
@@ -138,10 +141,10 @@
         }
       ],
       "dependencies": {
-        "web-streams-polyfill": "^3.0.3"
+        "node-domexception": "^1.0.0"
       },
       "engines": {
-        "node": "^12.20 || >= 14.13"
+        "node": ">=16.7"
       }
     },
     "node_modules/google-closure-compiler": {
@@ -242,6 +245,24 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
       "dev": true
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "engines": {
+        "node": ">=10.5.0"
+      }
     },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
@@ -346,14 +367,6 @@
       "dependencies": {
         "source-map": "^0.5.1"
       }
-    },
-    "node_modules/web-streams-polyfill": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.1.0.tgz",
-      "integrity": "sha512-wO9r1YnYe7kFBLHyyVEhV1H8VRWoNiNnuP+v/HUUmSTaRF8F93Kmd3JMrETx0f11GXxRek6OcL2QtjFIdc5WYw==",
-      "engines": {
-        "node": ">= 8"
-      }
     }
   },
   "dependencies": {
@@ -449,11 +462,11 @@
       "dev": true
     },
     "fetch-blob": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.1.2.tgz",
-      "integrity": "sha512-hunJbvy/6OLjCD0uuhLdp0mMPzP/yd2ssd1t2FCJsaA7wkWhpbp9xfuNVpv7Ll4jFhzp6T4LAupSiV9uOeg0VQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-4.0.0.tgz",
+      "integrity": "sha512-nPmnhRmpNMjYWnp9EBMGs6z5lq9RXed5W1vuZcECrsDVQInM8AMQSooVb3X183Aole60adzjWbH9qlRFWzDDTA==",
       "requires": {
-        "web-streams-polyfill": "^3.0.3"
+        "node-domexception": "^1.0.0"
       }
     },
     "google-closure-compiler": {
@@ -522,6 +535,11 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
       "dev": true
+    },
+    "node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="
     },
     "process-nextick-args": {
       "version": "2.0.1",
@@ -614,11 +632,6 @@
       "requires": {
         "source-map": "^0.5.1"
       }
-    },
-    "web-streams-polyfill": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.1.0.tgz",
-      "integrity": "sha512-wO9r1YnYe7kFBLHyyVEhV1H8VRWoNiNnuP+v/HUUmSTaRF8F93Kmd3JMrETx0f11GXxRek6OcL2QtjFIdc5WYw=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "homepage": "https://github.com/jimmywarting/FormData#readme",
   "dependencies": {
-    "fetch-blob": "^3.1.2"
+    "fetch-blob": "^4.0.0"
   },
   "devDependencies": {
     "@types/google-closure-compiler": "^0.0.19",


### PR DESCRIPTION
<!-- Thanks for contributing! -->

## The purpose of this PR is:
To decrease deps size from 8.7Mb to ~200Kb

## This is what had to change:
In the `fetch-blob` package version 3.x, there was a dependency on the `web-streams-polyfill` package, which had a large size. In version `fetch-blob@4`, this dependency was dropped

## This is what like reviewers to know:
The API in the major version of the `fetch-blob` package remains unchanged


-------------------------------------------------------------------------------------------------

<!-- Mark what you have done, Remove unnecessary ones. Add new tasks that may fit (like TODO's) -->
- [x] I prefixed the PR-title with `docs: `, `fix(area): `, `feat(area): ` or `breaking(area): `
- [ ] I updated ./CHANGELOG.md with a link to this PR or Issue
- [ ] I updated the README.md
- [ ] I Added unit test(s)

-------------------------------------------------------------------------------------------------

<!-- Add a `- fix #_NUMBER_` line for every Issue this PR solves. Do not comma separate them -->
- fix #000
